### PR TITLE
fix nav links to use absolute URLs

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,11 +35,11 @@
             </a>
             <nav class="menu-bar">
                 <ul class="nav-list">
-                    <li class="nav-item"><a href="#about-me">About</a></li>
-                    <li class="nav-item"><a href="#work-experience">Work Experience</a></li>
-                    <li class="nav-item"><a href="#hobbies">Hobbies</a></li>
-                    <li class="nav-item"><a href="#travel-map">Travel Map</a></li>
-                    <li class="nav-item"><a href="#education">Education</a></li>
+                    <li class="nav-item"><a href="/#about-me">About</a></li>
+                    <li class="nav-item"><a href="/#work-experience">Work Experience</a></li>
+                    <li class="nav-item"><a href="/hobbies">Hobbies</a></li>
+                    <li class="nav-item"><a href="/#travel-map">Travel Map</a></li>
+                    <li class="nav-item"><a href="/#education">Education</a></li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
I fixed minor issues I originally overlooked with the nav links. I updated the nav links so that the "Hobbies" link takes you to hobbies page. I also updated the `href` to use absolute URLs so that the nav works across pages. For example if you click "Education" link from the hobbies page it will take you to the education section on the home page.

## Screenshot
![new-nav](https://github.com/Satoshi-Sh/mlh-portfolio/assets/26678076/5b632f5c-64c8-4249-b7c8-65bc24bb22c7)
